### PR TITLE
skin.copacetic 1.0.1

### DIFF
--- a/skin.copacetic/16x9/Components_Viewtypes.xml
+++ b/skin.copacetic/16x9/Components_Viewtypes.xml
@@ -43,7 +43,7 @@
 			<control type="button">
 				<visible allowhiddenfocus="true">false</visible>
 				<!-- Grid position -->
-				<onfocus condition="Control.HasFocus(505) + Container.Content(files) + !ListItem.IsFolder">RunScript(script.copacetic.helper,action=clean_filename,label=$INFO[ListItem.Label])</onfocus>
+				<onfocus condition="Control.HasFocus(505) + Container.Content(files)">RunScript(script.copacetic.helper,action=clean_filename)</onfocus>
 				<onfocus condition="Control.Hasfocus(505)">SetProperty(GridView_Column,$INFO[Container.Column],home)</onfocus>
 				<onfocus condition="Control.Hasfocus(505)">SetProperty(GridView_Row,$INFO[Container.Row],home)</onfocus>
 				<!-- Multiart -->

--- a/skin.copacetic/16x9/Font.xml
+++ b/skin.copacetic/16x9/Font.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <fonts>
 
-	<fontset id="Inter" unicode="true">
+	<fontset id="Default" unicode="true">
 		<font>
 			<name>Main_Menu_Focused</name>
 			<filename>Inter/Inter-Black.ttf</filename>

--- a/skin.copacetic/addon.xml
+++ b/skin.copacetic/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.copacetic" version="1.0.0" name="Copacetic" provider-name="realcopacetic">
+<addon id="skin.copacetic" version="1.0.1" name="Copacetic" provider-name="realcopacetic">
 	<requires>
 		<import addon="xbmc.gui" version="5.16.0" />
-		<import addon="script.copacetic.helper" version="1.0.0" />
+		<import addon="script.copacetic.helper" version="1.0.1" />
 		<import addon="resource.fonts.copacetic" version="1.0.0" />
 		<import addon="script.skinshortcuts" version="1.1.5" />
 		<import addon="visualization.waveform" version="20.2.1" />


### PR DESCRIPTION
Fix for fontset issue preventing people from switching to the skin, thanks to @beatmasterRS for the fix.

### Description
Apologies for submitting a new pull request so quickly. Apparently there was an issue flagged on the forum just before it went down preventing some users from switching to the skin which @beatmasterRS was able to fix [here](https://github.com/realcopacetic/skin.copacetic/pull/1).

I didn't see this until after I had submitted my initial pull request.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-skins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
